### PR TITLE
Add/fix TimeZone information

### DIFF
--- a/api/agents/GET-agents-uri-discos.md
+++ b/api/agents/GET-agents-uri-discos.md
@@ -25,8 +25,8 @@ This path also supports the following querystring parameters:
 | Parameter| Description |
 |------|----|
 | status<br> (choose one) | DiSCO status filter: <br>- all<br>- active (default)<br>- inactive| 
-| from | Date from. Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more URIs than the limit, the system will automatically paginate and add `page=1` to your query string.
 

--- a/api/agents/GET-agents-uri-events.md
+++ b/api/agents/GET-agents-uri-events.md
@@ -25,8 +25,8 @@ This path also supports the following querystring parameters:
 
 | Parameter| Description |
 |------|----|
-| from | Date from. Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more URIs than the limit, the system will automatically paginate and add `page=1` to your query string.
 

--- a/api/discos/GET-discos-uri-timemap.md
+++ b/api/discos/GET-discos-uri-timemap.md
@@ -43,11 +43,11 @@ Example:
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18m7mr7/timemap>;rel="self";
     type="application/link-format",
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18mddcw>;rel="memento latest-version";
-    datetime="Wed, 29 Jul 2015 17:47:18 UTC",
+    datetime="Wed, 29 Jul 2015 17:47:18 GMT",
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18m7mr7>;rel="memento";
-    datetime="Fri, 24 Jul 2015 19:35:06 UTC",
+    datetime="Fri, 24 Jul 2015 19:35:06 GMT",
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18mdd8b>;rel="memento";
-    datetime="Wed, 29 Jul 2015 17:40:24 UTC"
+    datetime="Wed, 29 Jul 2015 17:40:24 GMT"
 ```
 
 #### Possible Response Codes
@@ -87,9 +87,9 @@ Content-Type: application/link-format
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18m7mr7/timemap>;rel="self";
     type="application/link-format",
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18mddcw>;rel="memento latest-version";
-    datetime="Wed, 29 Jul 2015 17:47:18 UTC",
+    datetime="Wed, 29 Jul 2015 17:47:18 GMT",
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18m7mr7>;rel="memento";
-    datetime="Fri, 24 Jul 2015 19:35:06 UTC",
+    datetime="Fri, 24 Jul 2015 19:35:06 GMT",
 <https://test.rmap-hub.org/api/discos/rmap%3Armd18mdd8b>;rel="memento";
-    datetime="Wed, 29 Jul 2015 17:40:24 UTC"
+    datetime="Wed, 29 Jul 2015 17:40:24 GMT"
 ```

--- a/api/discos/GET-discos-uri.md
+++ b/api/discos/GET-discos-uri.md
@@ -87,12 +87,12 @@ curl -i
 HTTP/1.1 200 OK
 Location: https://test.rmap-hub.org/api/discos/rmap%3A1c59zw43jh
 Link: <http://purl.org/ontology/rmap#active>;rel="http://purl.org/ontology/rmap#hasStatus"
-Link: <https://test.rmap-hub.org/api/discos/rmap%3A8w9ghx3tv6>;rel="predecessor-version memento";datetime="Fri, 19 Jan 2018 23:45:58 UTC"
-Link: <https://test.rmap-hub.org/api/discos/rmap%3A1c59zw43jh>;rel="latest-version memento";datetime="Fri, 19 Jan 2018 23:46:10 UTC"
+Link: <https://test.rmap-hub.org/api/discos/rmap%3A8w9ghx3tv6>;rel="predecessor-version memento";datetime="Fri, 19 Jan 2018 23:45:58 GMT"
+Link: <https://test.rmap-hub.org/api/discos/rmap%3A1c59zw43jh>;rel="latest-version memento";datetime="Fri, 19 Jan 2018 23:46:10 GMT"
 Link: <https://test.rmap-hub.org/api/discos/rmap%3A1c59zw43jh/events>;rel="http://www.w3.org/ns/prov#has_provenance"
 Link: <https://test.rmap-hub.org/api/discos/rmap%3Ajdfn2z3k6r/latest>;rel="original timegate"
 Link: <https://test.rmap-hub.org/api/discos/rmap%3Ajdfn2z3k6r/timemap>;rel="timemap"
-Memento-Datetime: Fri, 19 Jan 2018 23:46:10 UTC
+Memento-Datetime: Fri, 19 Jan 2018 23:46:10 GMT
 Content-Type: application/vnd.rmap-project.disco+rdf+xml; version=1.0
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/api/discos/HEAD-discos-uri.md
+++ b/api/discos/HEAD-discos-uri.md
@@ -81,11 +81,11 @@ curl -i -I HEAD https://test.rmap-hub.org/api/discos/rmap%3Ap8cz8w9xbq
 HTTP/1.1 200 OK
 Location: https://test.rmap-hub.org/api/discos/rmap%3Ap8cz8w9xbq
 Link: <http://purl.org/ontology/rmap#active>;rel="http://purl.org/ontology/rmap#hasStatus"
-Link: <https://test.rmap-hub.org/api/discos/rmap%3Ap8cz8w9xbq>;rel="latest-version memento";datetime="Fri, 19 Jan 2018 23:31:31 UTC"
+Link: <https://test.rmap-hub.org/api/discos/rmap%3Ap8cz8w9xbq>;rel="latest-version memento";datetime="Fri, 19 Jan 2018 23:31:31 GMT"
 Link: <https://test.rmap-hub.org/api/discos/rmap%3Ap8cz8w9xbq/events>;rel="http://www.w3.org/ns/prov#has_provenance"
 Link: <https://test.rmap-hub.org/api/discos/rmap%3Ap8cz8w9xbq/latest>;rel="original timegate"
 Link: <https://test.rmap-hub.org/api/discos/rmap%3Ap8cz8w9xbq/timemap>;rel="timemap"
-Memento-Datetime: Fri, 19 Jan 2018 23:31:31 UTC
+Memento-Datetime: Fri, 19 Jan 2018 23:31:31 GMT
 
 [no content]
 ```

--- a/api/resources/GET-resources-uri-agents.md
+++ b/api/resources/GET-resources-uri-agents.md
@@ -24,8 +24,8 @@ This path also supports the following querystring parameters:
 
 | Parameter| Description |
 |------|----|
-| from | Date from. Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 |agents| Comma separated list of RMap Agent URIs. This will filter by the Agent that generated the graph the Resource is contained in.|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more URIs than the limit, the system will automatically paginate and add `page=1` to your query string.

--- a/api/resources/GET-resources-uri-discos.md
+++ b/api/resources/GET-resources-uri-discos.md
@@ -25,8 +25,8 @@ This path also supports the following querystring parameters:
 | Parameter| Description |
 |------|----|
 |status| DiSCO status filter: <br>- all<br>- active _(default)_<br>- inactive |
-| from | Date from. Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 |agents| Comma separated list of RMap Agent URIs. This will filter by the Agent that generated the DiSCO.|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more URIs than the limit, the system will automatically paginate and add `page=1` to your query string.

--- a/api/resources/GET-resources-uri-events.md
+++ b/api/resources/GET-resources-uri-events.md
@@ -24,8 +24,8 @@ This path also supports the following querystring parameters:
 
 | Parameter| Description |
 |------|----|
-| from | Date from. Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to start date of the creation Event for the object that the Resource is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 |agents| Comma separated list of RMap Agent URIs. This will filter by the Agent that generated the graph the Resource is contained in.|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more URIs than the limit, the system will automatically paginate and add `page=1` to your query string.

--- a/api/resources/GET-resources-uri.md
+++ b/api/resources/GET-resources-uri.md
@@ -25,8 +25,8 @@ This path also supports the following querystring parameters:
 | Parameter| Description |
 |------|----|
 | status<br> (choose one) | DiSCO status filter: <br>- all<br>- active (default)<br>- inactive| 
-| from | Date from. Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to DiSCO creation Event start date. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 |agents| Comma separate list of RMap:Agent URIs, this will filter the triples by the Agent that generated the graph they are contained in.|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more triples than the limit, the system will automatically paginate and add `page=1` to your query string.

--- a/api/stmts/GET-stmts-spo-agents.md
+++ b/api/stmts/GET-stmts-spo-agents.md
@@ -27,8 +27,8 @@ This path also supports the following querystring parameters:
 | Parameter| Description |
 |------|----|
 |status| Status of DiSCO or Agent that contains the Statement<br>- all<br>- active _(default)_<br>- inactive |
-| from | Date from. Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 |agents| Comma separated list of RMap Agent URIs. This will filter by the Agent that generated the graph the Statement is contained in.|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more URIs than the limit, the system will automatically paginate and add `page=1` to your query string.

--- a/api/stmts/GET-stmts-spo-discos.md
+++ b/api/stmts/GET-stmts-spo-discos.md
@@ -27,8 +27,8 @@ This path also supports the following querystring parameters:
 | Parameter| Description |
 |------|----|
 |status| Status of DiSCO or Agent that contains the Statement<br>- all<br>- active _(default)_<br>- inactive |
-| from | Date from. Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
-|until | Date to. Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+| from | Date from (UTC). Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
+|until | Date to (UTC). Applied to start date of the creation Event for the object that the Statement is contained in. Format as _yyyyMMddHHmmss_ or _yyyyMMdd_ <br>e.g. 20150101120000|
 |agents| Comma separated list of RMap Agent URIs. This will filter by the Agent that generated the graph the Statement is contained in.|
 | page | Page number as integer of greater than 0. Default is 1.|
 | limit | Number of URIs to retrieve. Default is 200. If there are more URIs than the limit, the system will automatically paginate and add `page=1` to your query string.


### PR DESCRIPTION
Memento headers should use GMT. API calls that filter by date are applied as UTC.